### PR TITLE
Correct "GoSquared" spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Your feedback and contributions are always welcome!
 * [Foxmetrics](http://foxmetrics.com/%20) - analytics to track your user’s actions and activities.
 * [Google Analytics](http://www.google.com/analytics/) - de facto standard for analytics in the web analytics space.
 * [Clicktale](http://www.clicktale.com/) - record and watch exactly how a visitor used your website.
-* [Go Squared](https://www.gosquared.com/) - analytics with visitor tagging to help you dig deeper into one user’s visit.
+* [GoSquared](https://www.gosquared.com/) - analytics with visitor tagging to help you dig deeper into one user’s visit.
 * [Clicky](http://clicky.com/) - track visits and conversions, you can also track your video and audio analytics.
 * [Woopra](https://www.woopra.com/) - track where your users are coming from.
 * [Mint](http://haveamint.com/) - elf-hosted analytics solution. 


### PR DESCRIPTION
Listed as "Go Squared", but official name is "GoSquared" (all one word)