### PR TITLE
removed https://ducksboard.com/

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Often there is no clear differentiation between social media management and anal
 
 * [Freeboard](https://github.com/Freeboard/freeboard) - open source real-time dashboard builder for IOT and other web mashups.
 * [Geckboard](https://www.geckoboard.com/) - dashboard for key metrics in one place.
-* [Ducksboard](https://ducksboard.com/) - visualize and share the data that matters most to you and your team.
 
 # Other Awesome Lists
 - Other awesome lists [awesome-awesomeness](https://github.com/bayandin/awesome-awesomeness).


### PR DESCRIPTION
Ducksboard was acquired by New Relic, Inc. in October 2014. and discontinioud 