### PR TITLE
Remove discontinued product (PadiTrack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Your feedback and contributions are always welcome!
 * [Statcountr](http://statcounter.com/) - one of the ORIGINAL web analytics tools available.
 * [Snow Plow](http://snowplowanalytics.com/) - analytics tool for web apps with a lot of data.
 * [Adobe Digital Analytics](http://www.adobe.com/solutions/digital-analytics/marketing-reports-analytics.html) - standard analytics tools plus some that large organizations can use.
-* [Paditrack.com/](https://paditrack.com/) - analyze any data from Google Analytics, including the data you had before.
 * [Hitslink.com/](http://www.hitslink.com/) - real-time analytics, social media traffic reporting, and real-time dynamic segmentation.
 * [parse.ly ](http://parse.ly%20) - real-time web analytics tool with a focus on tracking content.
 * [Loggr](http://loggr.net/) -  track your user events and monitor your web app.


### PR DESCRIPTION
PadiTrack has been discontinued and the website is not available anymore.
See [this blog article](http://www.ganotes.com/paditrack-discontinued-heres-a-google-spreadsheets-alternative/)
