### PR TITLE
Remove discontinued product (Reinvigorate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Your feedback and contributions are always welcome!
 
 ## Heatmap analytics
 
-* [Reinviorate](https://www.reinvigorate.net/) - real-time analytics tool with heatmaps.
 * [Crazyegg](http://www.crazyegg.com/) - a heatmaps only analtyics tool.
 * [Inspeclet](https://www.inspectlet.com/) - another web app heatmaps tool.
 * [Mouseflow](http://mouseflow.com/%20) - live analytics and heatmaps.


### PR DESCRIPTION
It was acquired and integrated into Webtrends.
See: https://www.facebook.com/reinvigorate/
