### PR TITLE
Update links and info for piratepx

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Your feedback and contributions are always welcome! Maintained by [@onurakpolat]
 * [Freshlytics](https://github.com/sheshbabu/freshlytics) - Privacy respecting, cookie free and low resource usage analytics platform. `MIT` `Docker/Nodejs`
 * [Kindmetrics](https://kindmetrics.io/) - Clean privacy-focused website analytics. ([Source Code](https://github.com/kindmetrics/kindmetrics)) `MIT` `Crystal`
 * [Ackee](https://ackee.electerious.com) - Self-hosted analytics tool for those who care about privacy. ([Demo](http://demo.ackee.electerious.com), [Source Code](https://github.com/electerious/Ackee)) `MIT` `Nodejs`
-* [piratepx](https://www.piratepx.com/) - Just a little analytics insight for your personal or indie project. 100% free and open source.
+* [piratepx](https://www.piratepx.com/) - Just a little analytics insight for your personal or indie project. 100% free and open source. ([Demo](https://app.piratepx.com/shared/bGQbUJ-YADC_xIGZaYmyqp-J_PD6O1pkCdHmYdIjUvs53ExsImlzFeou4MCuZRbH), [Source](https://github.com/piratepx/app)) `MIT` `Nodejs`
 
 ## Heatmap analytics
 


### PR DESCRIPTION
Added links to demo and source for piratepx on GitHub, also added `MIT` and `Nodejs` tags